### PR TITLE
Added the ability to delete supports between characters.

### DIFF
--- a/src/fefeditor/bin/SupportBin.scala
+++ b/src/fefeditor/bin/SupportBin.scala
@@ -198,8 +198,7 @@ class SupportBin(file: File)
     }).toBuffer
 
     // Remove data.
-    for (x <- 0 until bytes.length)
-      data.remove(deleteOffset)
+    data.remove(deleteOffset, bytes.length)
 
     // Fix data and pointer one using recalculated pointers.
     for(x <- newPtrOne.indices) {

--- a/src/fefeditor/bin/SupportBin.scala
+++ b/src/fefeditor/bin/SupportBin.scala
@@ -166,6 +166,60 @@ class SupportBin(file: File)
     }
   }
 
+  def removeSupport(character: SupportCharacter, index: Int, bytes: Array[Byte]): Unit = {
+    val temp = data.toArray
+    val tableOffset = offsets(character.getSupportId)
+    val tableSize = ArrayUtils.getUInt16(temp, tableOffset + 2)
+    val deleteOffset = tableOffset + 0x4 + index * 0xC
+
+    val sizeBytes = ArrayConvert.toByteArray(tableSize - 1)
+    for(x <- 0 until 2)
+      data(tableOffset + 2 + x) = sizeBytes(x)
+
+    // Fix pointers.
+    var newPtrOne = ptrOneList().toBuffer
+    var newPtrTwo = ptrTwoList().toBuffer
+    newPtrOne = List.tabulate(newPtrOne.length) (n => {
+      var newPtr = newPtrOne(n)._1
+      var newDataPtr = newPtrOne(n)._2
+      if(newPtr >= deleteOffset) {
+        newPtr -= bytes.length
+      }
+      if(newDataPtr >= deleteOffset) {
+        newDataPtr -= bytes.length
+      }
+      (newPtr, newDataPtr)
+    }).toBuffer
+    newPtrTwo = List.tabulate(newPtrTwo.length) (n => {
+      var newPtr = newPtrTwo(n)._1
+      if(newPtr > deleteOffset)
+        newPtr -= bytes.length
+      (newPtr, newPtrTwo(n)._2)
+    }).toBuffer
+
+    // Remove data.
+    for (x <- 0 until bytes.length)
+      data.remove(deleteOffset)
+
+    // Fix data and pointer one using recalculated pointers.
+    for(x <- newPtrOne.indices) {
+      val ptrBytes = ArrayConvert.toByteArray(newPtrOne(x)._1)
+      val dataBytes = ArrayConvert.toByteArray(newPtrOne(x)._2)
+      for(y <- 0 until 4) {
+        ptrOne(x * 4 + y) = ptrBytes(y)
+        data(newPtrOne(x)._1 + y) = dataBytes(y)
+      }
+    }
+
+    // Fix pointer two using recalculated pointers.
+    for(x <- newPtrTwo.indices) {
+      val ptrBytes = ArrayConvert.toByteArray(newPtrTwo(x)._1)
+      for(y <- 0 until 4) {
+        ptrTwo(x * 8 + y) = ptrBytes(y)
+      }
+    }
+  }
+
   def addSupportTable(bytes: Array[Byte], supportId: Short, blockStart: Int): Unit = {
     val temp = data.toArray
     val tableOffset = offsets.last


### PR DESCRIPTION
![Screenshot 1](https://i.imgur.com/Krj0U7S.png)
![Screenshot 2](https://i.imgur.com/aQG50cS.png)
I heard that you were holding off on this due to its slightly increased difficulty, so I went ahead and took care of it for you since I had a few minutes.

Here's hoping I get enough time soon to get back to work on my own stuff!

Edit: Please do note that I know little about Scala and didn't think to look much up. I strongly suspect that the loop on line 201 of `src/fefeditor/bin/SupportBin.scala` can be replaced with a single method call.

Edit edit: Indeed it can. Replaced it with `data.remove(deleteOffset, bytes.length)`.